### PR TITLE
Add hover display of delete link for sticky notes

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -64,6 +64,7 @@ ul.dropdown-menu {
   flex-wrap: wrap;
   .sticky-note {
     display: flex;
+    justify-content: space-between;
     height: 250px;
     border: 1px solid rgb(255 255 255 / 50%);
     border-top-color: rgb(175 175 175 / 10%);
@@ -147,4 +148,17 @@ select option:nth-child(5) {
 }
 select option:nth-child(6) {
   background-color: #e76f51;
+}
+
+[id^="sticky_note"] {
+  .sticky-note-delete {
+    display: none;
+  }
+  &:hover {
+    .sticky-note-delete {
+      display: inline;
+      text-decoration: none;
+      color: red;
+    }
+  }
 }

--- a/app/views/sticky_notes/_sticky_note.html.erb
+++ b/app/views/sticky_notes/_sticky_note.html.erb
@@ -1,6 +1,7 @@
 
 <div class="col">
-  <div id="<%= dom_id(sticky_note) %>" style="background-color: <%= sticky_note.color; %>" class="sticky-note" data-id="<%= sticky_note.id %>">
+  <div id="<%= dom_id(sticky_note) %>" style="background-color: <%= sticky_note.color; %>" class="sticky-note" data-id="<%= sticky_note.id %>" data-action="mouseover->note#displayDelete mouseout->note#displayDelete">
     <p><%= sticky_note.content %></p>
+    <%= link_to fa_icon('trash'), sticky_note, data: { turbo_method: :delete }, class: "sticky-note-delete" %>
   </div>
 </div>


### PR DESCRIPTION
Hovering over a sticky note now displays an icon in the corner, which is a link_to helper to delete the hovered-over sticky note. 