### PR TITLE
Implement toggling between active and inactive sticky notes

### DIFF
--- a/app/controllers/whiteboards_controller.rb
+++ b/app/controllers/whiteboards_controller.rb
@@ -11,7 +11,7 @@ class WhiteboardsController < ApplicationController
     authorize @whiteboard
 
     if @whiteboard.save
-      redirect_to @workspace, notice: 'Whiteboard was successfully created.'
+      redirect_to @workspace, notice: "Whiteboard was successfully created."
     else
       render :new
     end
@@ -19,6 +19,11 @@ class WhiteboardsController < ApplicationController
 
   def show
     @whiteboard = Whiteboard.find(params[:id])
+    authorize @whiteboard
+  end
+
+  def completed
+    @whiteboard = Whiteboard.find(params[:whiteboard_id])
     authorize @whiteboard
   end
 

--- a/app/policies/whiteboard_policy.rb
+++ b/app/policies/whiteboard_policy.rb
@@ -12,6 +12,10 @@ class WhiteboardPolicy < ApplicationPolicy
     user == record.workspace.owner
   end
 
+  def completed?
+    user == record.workspace.owner
+  end
+
   def update?
     # The user can update the whiteboard if they own it (assuming `whiteboard` has an `user` association)
     user.present? && record.user == user

--- a/app/views/sticky_notes/_sticky_note.html.erb
+++ b/app/views/sticky_notes/_sticky_note.html.erb
@@ -3,6 +3,6 @@
   <div style="background-color: <%= sticky_note.color; %>" class="sticky-note" data-action="mouseover->note#displayDelete mouseout->note#displayDelete" data-controller="drag"
      data-drag-url-value="/sticky_notes/:id/location" data-id="<%= sticky_note.id %>" data-drag-attribute-value="position" data-drag-target="sticky-note">
     <p><%= sticky_note.content %></p>
-    <%= render partial: 'sticky_notes/controls', locals: { sticky_note: } %>
+    <%= render partial: 'sticky_notes/controls', locals: { sticky_note: } if sticky_note.active %>
   </div>
 </div>

--- a/app/views/whiteboards/_completed_whiteboard.html.erb
+++ b/app/views/whiteboards/_completed_whiteboard.html.erb
@@ -1,0 +1,4 @@
+<%= turbo_frame_tag "sticky-notes" do %>
+  <%= link_to "Active Notes", workspace_whiteboard_path(id: whiteboard.id) %>
+  <%= render whiteboard.sticky_notes.inactive %>
+<% end %>

--- a/app/views/whiteboards/_whiteboard.html.erb
+++ b/app/views/whiteboards/_whiteboard.html.erb
@@ -5,10 +5,11 @@
       <h3 class="board-title"><%= whiteboard.title %></h3>
     </div>
     <div class="card-body" >
-      <div id="sticky-notes" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4 g-3" class="sticky-note" data-drag-target="list" data-new-value="position">
-        <%= render whiteboard.sticky_notes %>
-        <%= render partial: "sticky_notes/sticky_note_placeholder", locals: { whiteboard_id: whiteboard.id } %>
-      </div>
+        <%= turbo_frame_tag "sticky-notes", class: "row row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4 g-3 sticky-note" do %>
+          <%= link_to "Completed", workspace_whiteboard_completed_path(whiteboard_id: whiteboard.id, workspace_id: whiteboard.workspace.id) %>
+          <%= render whiteboard.sticky_notes.active %>
+          <%= render partial: "sticky_notes/sticky_note_placeholder", locals: { whiteboard_id: whiteboard.id } %>
+        <% end %>
     </div>
   </div>
 </div>

--- a/app/views/whiteboards/completed.html.erb
+++ b/app/views/whiteboards/completed.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "whiteboards/completed_whiteboard", locals: { whiteboard: @whiteboard } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,9 @@ Rails.application.routes.draw do
   root to: "dashboard#index"
 
   resources :workspaces do
-    resources :whiteboards
+    resources :whiteboards do
+      get "/completed", to: "whiteboards#completed"
+    end
   end
   resources :sticky_notes, except: [:index]
-
 end


### PR DESCRIPTION
Users can now click a link to switch between uncompleted sticky notes (active) and completed sticky notes (inactive) for individual whiteboards, implemented with Turbo Frames. This required a custom nested route and completed action to be added to the whiteboards controller, along with updating the whiteboard policy. I also needed to create special partials and erb for rendering sets of completed notes.