### PR TITLE
Fix turbo bug regarding misplaced sticky notes

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -59,7 +59,7 @@ ul.dropdown-menu {
   }
 }
 
-#sticky-notes {
+.sticky-notes {
   display: flex;
   flex-wrap: wrap;
   .sticky-note {

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -31,18 +31,29 @@ ul.dropdown-menu {
 }
 
 #workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
   #workspace-title {
+    align-self: center;
     color: #4b5567;
     font-weight: 700;
+    border-bottom: 2px solid;
   }
 }
 
 #whiteboards {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
   .card {
     border: 1px solid #758895;
   }
   .board-header {
-    background: #4b5963;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background-color: #a5b5bf;
     padding: 0.5em 1em;
     color: #fff;
     border-radius: 0.3em 0.3em 0 0;
@@ -55,6 +66,10 @@ ul.dropdown-menu {
       margin: 0;
       font-size: 1.1em;
       font-weight: 700;
+    }
+    .board-nav {
+      display: flex;
+      gap: 1rem;
     }
   }
 }

--- a/app/controllers/sticky_notes_controller.rb
+++ b/app/controllers/sticky_notes_controller.rb
@@ -17,7 +17,7 @@ class StickyNotesController < ApplicationController
 
   def create
     @sticky_note = build_sticky_note_with_owner(sticky_note_params)
-    @whiteboard_id = sticky_note_params[:whiteboard_id]
+    @whiteboard = Whiteboard.find(sticky_note_params[:whiteboard_id])
     authorize(@sticky_note)
     respond_to do |format|
       if @sticky_note.save

--- a/app/views/shared/_application_nav.html.erb
+++ b/app/views/shared/_application_nav.html.erb
@@ -13,11 +13,6 @@
         <% end %>
       </li>
       <li>
-      <li class="nav-item">
-        <%= link_to(new_sticky_note_path, class: "nav-link text-uppercase text-center") do %>
-          <i class="fa fa-xl fa-list-check"></i><br>Completed
-        <% end %>
-      </li>
       <% if user_signed_in? %>
         <li class="nav-item dropdown">
           <%= link_to "#", data: { "bs-toggle": "dropdown" }, class: "nav-link dropdown-toggle", role: "button" do %>

--- a/app/views/sticky_notes/_controls.html.erb
+++ b/app/views/sticky_notes/_controls.html.erb
@@ -1,10 +1,9 @@
 <nav class="breadcrumb blogcrumb">
-  <%= link_to fa_icon('pencil-square-o'), edit_sticky_note_path(sticky_note), class: "sticky-note-hidden" %>
-  <%= link_to fa_icon('trash'), sticky_note, data: { turbo_method: :delete,
-                        turbo_confirm: 'Are you sure?' }, class: "sticky-note-hidden" %>
-  <%= form_with model: sticky_note do |form| %>
+  <%= link_to fa_icon('pencil-square-o'), edit_workspace_whiteboard_sticky_note_path(id: sticky_note.id, whiteboard_id: sticky_note.whiteboard.id, workspace_id: sticky_note.whiteboard.workspace.id), class: "sticky-note-hidden" %>
+  <%= link_to fa_icon('trash'), workspace_whiteboard_sticky_note_path(id: sticky_note.id, whiteboard_id: sticky_note.whiteboard.id, workspace_id: sticky_note.whiteboard.workspace.id), data: { turbo_method: :delete,
+                        turbo_confirm: 'Are you sure?', turbo_frame: "_top" }, class: "sticky-note-hidden" %>
+  <%= form_with model: [sticky_note.whiteboard.workspace, sticky_note.whiteboard, sticky_note] do |form| %>
     <%= form.hidden_field :active, value: false  %>
     <%= form.button fa_icon('circle-check'), class: "sticky-note-hidden" %>
   <% end %>
 </nav>
-

--- a/app/views/sticky_notes/_controls.html.erb
+++ b/app/views/sticky_notes/_controls.html.erb
@@ -1,8 +1,8 @@
 <nav class="breadcrumb blogcrumb">
-  <%= link_to fa_icon('pencil-square-o'), edit_workspace_whiteboard_sticky_note_path(id: sticky_note.id, whiteboard_id: sticky_note.whiteboard.id, workspace_id: sticky_note.whiteboard.workspace.id), class: "sticky-note-hidden" %>
-  <%= link_to fa_icon('trash'), workspace_whiteboard_sticky_note_path(id: sticky_note.id, whiteboard_id: sticky_note.whiteboard.id, workspace_id: sticky_note.whiteboard.workspace.id), data: { turbo_method: :delete,
+  <%= link_to fa_icon('pencil-square-o'), edit_sticky_note_path(id: sticky_note.id), class: "sticky-note-hidden" %>
+  <%= link_to fa_icon('trash'), sticky_note_path(id: sticky_note.id), data: { turbo_method: :delete,
                         turbo_confirm: 'Are you sure?', turbo_frame: "_top" }, class: "sticky-note-hidden" %>
-  <%= form_with model: [sticky_note.whiteboard.workspace, sticky_note.whiteboard, sticky_note] do |form| %>
+  <%= form_with model: sticky_note do |form| %>
     <%= form.hidden_field :active, value: false  %>
     <%= form.button fa_icon('circle-check'), class: "sticky-note-hidden" %>
   <% end %>

--- a/app/views/sticky_notes/_form.html.erb
+++ b/app/views/sticky_notes/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: sticky_note, class: "sticky-note", data: { controller: "note", note_target: "form" }) do |form| %>
+<%= form_with(model: sticky_note, class: "sticky-note", html: { style: "background-color: #{sticky_note.color};" }, data: { controller: "note", note_target: "form" }) do |form| %>
   <% if sticky_note.errors.any? %>
     <div style="color: red">
       <ul>
@@ -10,13 +10,13 @@
   <% end %>
 
   <div class="d-flex h-100">
-    <%= form.text_area :content, class: "sticky-note-form", autofocus: true, data: {
+    <%= form.text_area :content, class: "sticky-note-form", style: "background-color: #{sticky_note.color};", autofocus: true, data: {
       action: "keydown.enter->note#submitNote", note_target: "textarea"
     } %>
   </div>
   
   <div>
-    <%= form.select :color, [['', '#fff9af'], ['', '#264653'], ['', '#2A9D8F'], ['', '#E9C46A'], ['', '#F4A261'], ['', '#E76F51']], {}, data: { action: "change->note#changeSelectColor", note_target: "select" }  %>
+    <%= form.select :color, [['', '#fff9af'], ['', '#264653'], ['', '#2A9D8F'], ['', '#E9C46A'], ['', '#F4A261'], ['', '#E76F51']], {}, data: { action: "change->note#changeSelectColor", note_target: "select" }, style: "background-color: #{sticky_note.color};"  %>
   </div>
 
   <div>

--- a/app/views/sticky_notes/_sticky_note.html.erb
+++ b/app/views/sticky_notes/_sticky_note.html.erb
@@ -1,8 +1,9 @@
-
-<div id="<%= dom_id(sticky_note) %>" class="col">
-  <div style="background-color: <%= sticky_note.color; %>" class="sticky-note" data-action="mouseover->note#displayDelete mouseout->note#displayDelete" data-controller="drag"
-     data-drag-url-value="/sticky_notes/:id/location" data-id="<%= sticky_note.id %>" data-drag-attribute-value="position" data-drag-target="sticky-note">
-    <p><%= sticky_note.content %></p>
-    <%= render partial: 'sticky_notes/controls', locals: { sticky_note: } if sticky_note.active %>
+<%= turbo_frame_tag sticky_note do %>
+  <div id="<%= dom_id(sticky_note) %>" class="col">
+    <div style="background-color: <%= sticky_note.color; %>" class="sticky-note" data-action="mouseover->note#displayDelete mouseout->note#displayDelete" data-controller="drag"
+      data-drag-url-value="/sticky_notes/:id/location" data-id="<%= sticky_note.id %>" data-drag-attribute-value="position" data-drag-target="sticky-note">
+        <p><%= sticky_note.content %></p>
+        <%= render partial: 'sticky_notes/controls', locals: { sticky_note: sticky_note } if sticky_note.active %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/sticky_notes/_sticky_note_placeholder.html.erb
+++ b/app/views/sticky_notes/_sticky_note_placeholder.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag id="new-note" do %>
+<%= turbo_frame_tag id="new-note-#{whiteboard_id}" do %>
   <%= link_to new_sticky_note_path(whiteboard_id:), class: "sticky-note add-note w-100 h-100 d-flex flex-column align-items-center justify-content-center" do %>
     <i class="fa fa-xl fa-file-circle-plus"></i><br>
     New Note

--- a/app/views/sticky_notes/_sticky_note_placeholder.html.erb
+++ b/app/views/sticky_notes/_sticky_note_placeholder.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag id="new-note-#{whiteboard.id}" do %>
-  <%= link_to new_workspace_whiteboard_sticky_note_path(whiteboard_id: whiteboard.id, workspace_id: whiteboard.workspace.id), class: "sticky-note add-note w-100 h-100 d-flex flex-column align-items-center justify-content-center" do %>
+  <%= link_to new_sticky_note_path(whiteboard_id: whiteboard.id), class: "sticky-note add-note w-100 h-100 d-flex flex-column align-items-center justify-content-center" do %>
     <i class="fa fa-xl fa-file-circle-plus"></i><br>
     New Note
   <% end %>

--- a/app/views/sticky_notes/_sticky_note_placeholder.html.erb
+++ b/app/views/sticky_notes/_sticky_note_placeholder.html.erb
@@ -1,5 +1,5 @@
-<%= turbo_frame_tag id="new-note-#{whiteboard_id}" do %>
-  <%= link_to new_sticky_note_path(whiteboard_id:), class: "sticky-note add-note w-100 h-100 d-flex flex-column align-items-center justify-content-center" do %>
+<%= turbo_frame_tag id="new-note-#{whiteboard.id}" do %>
+  <%= link_to new_workspace_whiteboard_sticky_note_path(whiteboard_id: whiteboard.id, workspace_id: whiteboard.workspace.id), class: "sticky-note add-note w-100 h-100 d-flex flex-column align-items-center justify-content-center" do %>
     <i class="fa fa-xl fa-file-circle-plus"></i><br>
     New Note
   <% end %>

--- a/app/views/sticky_notes/create.turbo_stream.erb
+++ b/app/views/sticky_notes/create.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.replace "new-note-#{@sticky_note.whiteboard.id}", @sticky_note %>
+<%= turbo_stream.replace "new-note-#{@whiteboard.id}", @sticky_note %>
 <%= turbo_stream.append @whiteboard do %>
-  <%= render partial: "sticky_notes/sticky_note_placeholder", locals: { whiteboard_id: @whiteboard.id } %>
+  <%= render partial: "sticky_notes/sticky_note_placeholder", locals: { whiteboard: @whiteboard } %>
 <% end %>

--- a/app/views/sticky_notes/create.turbo_stream.erb
+++ b/app/views/sticky_notes/create.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.replace "new-note", @sticky_note %>
-<%= turbo_stream.append "sticky-notes" do %>
-  <%= render partial: "sticky_notes/sticky_note_placeholder", locals: { whiteboard_id: @whiteboard_id } %>
+<%= turbo_stream.replace "new-note-#{@sticky_note.whiteboard.id}", @sticky_note %>
+<%= turbo_stream.append @whiteboard do %>
+  <%= render partial: "sticky_notes/sticky_note_placeholder", locals: { whiteboard_id: @whiteboard.id } %>
 <% end %>

--- a/app/views/sticky_notes/edit.html.erb
+++ b/app/views/sticky_notes/edit.html.erb
@@ -1,6 +1,8 @@
 <h1>Editing sticky note</h1>
 
-<%= render "sticky_notes/form", sticky_note: @sticky_note %>
+<%= turbo_frame_tag @sticky_note do %>
+  <%= render partial: "sticky_notes/form", locals: { sticky_note: @sticky_note,  whiteboard_id: @sticky_note.whiteboard.id } %>
+<% end %>
 
 <br>
 

--- a/app/views/sticky_notes/new.html.erb
+++ b/app/views/sticky_notes/new.html.erb
@@ -1,5 +1,5 @@
 <h1>New sticky note</h1>
-<%= turbo_frame_tag id="new-note" do %>
+<%= turbo_frame_tag id="new-note-#{@whiteboard_id}" do %>
   <%= render partial: "sticky_notes/form", locals: { sticky_note: @sticky_note, whiteboard_id: @whiteboard_id } %>
 <% end %>
 <br>

--- a/app/views/sticky_notes/update.turbo_stream.erb
+++ b/app/views/sticky_notes/update.turbo_stream.erb
@@ -1,1 +1,2 @@
-<%= turbo_stream.remove @sticky_note %>
+<%= turbo_stream.remove @sticky_note unless @sticky_note.active %>
+<%= turbo_stream.replace @sticky_note, @sticky_note if @sticky_note.active %> 

--- a/app/views/whiteboards/_completed_whiteboard.html.erb
+++ b/app/views/whiteboards/_completed_whiteboard.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "sticky-notes" do %>
+<%= turbo_frame_tag whiteboard do %>
   <%= link_to "Active Notes", workspace_whiteboard_path(id: whiteboard.id) %>
   <%= render whiteboard.sticky_notes.inactive %>
 <% end %>

--- a/app/views/whiteboards/_completed_whiteboard.html.erb
+++ b/app/views/whiteboards/_completed_whiteboard.html.erb
@@ -1,4 +1,3 @@
 <%= turbo_frame_tag whiteboard do %>
-  <%= link_to "Active Notes", workspace_whiteboard_path(id: whiteboard.id) %>
   <%= render whiteboard.sticky_notes.inactive %>
 <% end %>

--- a/app/views/whiteboards/_whiteboard.html.erb
+++ b/app/views/whiteboards/_whiteboard.html.erb
@@ -3,12 +3,17 @@
     <div class="board-header">
       <i class="fa fa-lg fa-note-sticky"></i>
       <h3 class="board-title"><%= whiteboard.title %></h3>
+      <li class="nav-item">
+        <%= link_to workspace_whiteboard_completed_path(whiteboard_id: whiteboard.id, workspace_id: whiteboard.workspace.id), data: { turbo_frame: "whiteboard_#{whiteboard.id}" }, class: "nav-link text-uppercase text-center" do %>
+          <i class="fa fa-xl fa-list-check"></i><br>Completed
+        <% end %>
+      </li>
     </div>
     <div class="card-body" >
         <%= turbo_frame_tag whiteboard, class: "row row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4 g-3 sticky-note sticky-notes" do %>
           <%= link_to "Completed", workspace_whiteboard_completed_path(whiteboard_id: whiteboard.id, workspace_id: whiteboard.workspace.id) %>
           <%= render whiteboard.sticky_notes.active %>
-          <%= render partial: "sticky_notes/sticky_note_placeholder", locals: { whiteboard_id: whiteboard.id } %>
+          <%= render partial: "sticky_notes/sticky_note_placeholder", locals: { whiteboard: whiteboard } %>
         <% end %>
     </div>
   </div>

--- a/app/views/whiteboards/_whiteboard.html.erb
+++ b/app/views/whiteboards/_whiteboard.html.erb
@@ -3,15 +3,17 @@
     <div class="board-header">
       <i class="fa fa-lg fa-note-sticky"></i>
       <h3 class="board-title"><%= whiteboard.title %></h3>
-      <li class="nav-item">
+        <nav class="board-nav">
         <%= link_to workspace_whiteboard_completed_path(whiteboard_id: whiteboard.id, workspace_id: whiteboard.workspace.id), data: { turbo_frame: "whiteboard_#{whiteboard.id}" }, class: "nav-link text-uppercase text-center" do %>
           <i class="fa fa-xl fa-list-check"></i><br>Completed
         <% end %>
-      </li>
+        <%= link_to workspace_whiteboard_path(id: whiteboard.id, workspace_id: whiteboard.workspace.id), data: { turbo_frame: "whiteboard_#{whiteboard.id}" }, class: "nav-link text-uppercase text-center" do %>
+          <i class="fa fa-xl fa-list-check"></i><br>Active
+        <% end %>
+        </nav>
     </div>
     <div class="card-body" >
         <%= turbo_frame_tag whiteboard, class: "row row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4 g-3 sticky-note sticky-notes" do %>
-          <%= link_to "Completed", workspace_whiteboard_completed_path(whiteboard_id: whiteboard.id, workspace_id: whiteboard.workspace.id) %>
           <%= render whiteboard.sticky_notes.active %>
           <%= render partial: "sticky_notes/sticky_note_placeholder", locals: { whiteboard: whiteboard } %>
         <% end %>

--- a/app/views/whiteboards/_whiteboard.html.erb
+++ b/app/views/whiteboards/_whiteboard.html.erb
@@ -4,10 +4,10 @@
       <i class="fa fa-lg fa-note-sticky"></i>
       <h3 class="board-title"><%= whiteboard.title %></h3>
         <nav class="board-nav">
-        <%= link_to workspace_whiteboard_completed_path(whiteboard_id: whiteboard.id, workspace_id: whiteboard.workspace.id), data: { turbo_frame: "whiteboard_#{whiteboard.id}" }, class: "nav-link text-uppercase text-center" do %>
+        <%= link_to whiteboard_completed_path(whiteboard_id: whiteboard.id), data: { turbo_frame: "whiteboard_#{whiteboard.id}" }, class: "nav-link text-uppercase text-center" do %>
           <i class="fa fa-xl fa-list-check"></i><br>Completed
         <% end %>
-        <%= link_to workspace_whiteboard_path(id: whiteboard.id, workspace_id: whiteboard.workspace.id), data: { turbo_frame: "whiteboard_#{whiteboard.id}" }, class: "nav-link text-uppercase text-center" do %>
+        <%= link_to whiteboard_path(id: whiteboard.id), data: { turbo_frame: "whiteboard_#{whiteboard.id}" }, class: "nav-link text-uppercase text-center" do %>
           <i class="fa fa-xl fa-list-check"></i><br>Active
         <% end %>
         </nav>

--- a/app/views/whiteboards/_whiteboard.html.erb
+++ b/app/views/whiteboards/_whiteboard.html.erb
@@ -5,7 +5,7 @@
       <h3 class="board-title"><%= whiteboard.title %></h3>
     </div>
     <div class="card-body" >
-        <%= turbo_frame_tag "sticky-notes", class: "row row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4 g-3 sticky-note" do %>
+        <%= turbo_frame_tag whiteboard, class: "row row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4 g-3 sticky-note sticky-notes" do %>
           <%= link_to "Completed", workspace_whiteboard_completed_path(whiteboard_id: whiteboard.id, workspace_id: whiteboard.workspace.id) %>
           <%= render whiteboard.sticky_notes.active %>
           <%= render partial: "sticky_notes/sticky_note_placeholder", locals: { whiteboard_id: whiteboard.id } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,11 +9,13 @@ Rails.application.routes.draw do
   root to: "dashboard#index"
 
   resources :sticky_notes, except: [:index]
+  resources :whiteboards do
+    get "/completed", to: "whiteboards#completed"
+  end
 
   resources :workspaces do
     resources :whiteboards do
       resources :sticky_notes, except: [:index]
-      get "/completed", to: "whiteboards#completed"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,12 @@ Rails.application.routes.draw do
 
   root to: "dashboard#index"
 
+  resources :sticky_notes, except: [:index]
+
   resources :workspaces do
     resources :whiteboards do
+      resources :sticky_notes, except: [:index]
       get "/completed", to: "whiteboards#completed"
     end
   end
-  resources :sticky_notes, except: [:index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,9 +13,5 @@ Rails.application.routes.draw do
     get "/completed", to: "whiteboards#completed"
   end
 
-  resources :workspaces do
-    resources :whiteboards do
-      resources :sticky_notes, except: [:index]
-    end
-  end
+  resources :workspaces
 end


### PR DESCRIPTION
Fixed bug that arose due to turbo frames not having unique IDs, causing the turbo stream to add new sticky notes/form partials to an incorrect whiteboard.